### PR TITLE
Remove the internal storage of tokenId and authKey in the token.

### DIFF
--- a/msisdn-gateway/token.js
+++ b/msisdn-gateway/token.js
@@ -19,9 +19,9 @@ Token.prototype = {
     var self = this;
     var data = new Buffer(this.sessionToken, "hex");
     hkdf(data, "sessionToken", null, 2 * 32, function(keyMaterial) {
-      self.tokenId = keyMaterial.slice(0, 32).toString("hex");
-      self.authKey = keyMaterial.slice(32, 64).toString("hex");
-      callback(self.tokenId, self.authKey, self.sessionToken);
+      var tokenId = keyMaterial.slice(0, 32).toString("hex");
+      var authKey = keyMaterial.slice(32, 64).toString("hex");
+      callback(tokenId, authKey, self.sessionToken);
     });
   }
 };

--- a/test/token_test.js
+++ b/test/token_test.js
@@ -9,7 +9,7 @@ var Token = require("../msisdn-gateway/token").Token;
 
 describe("Token", function() {
   describe("#constructor", function() {
-    it("should generate a new sessionToken if not provide.", function() {
+    it("should generate a new sessionToken if not provided.", function() {
       var token = new Token();
       expect(token.hasOwnProperty("sessionToken")).to.equal(true);
       expect(token.sessionToken).to.length(64);
@@ -28,14 +28,9 @@ describe("Token", function() {
       var sessionToken = crypto.randomBytes(32).toString("hex");
       var token = new Token(sessionToken);
       token.getCredentials(function(tokenId, tokenAuthKey, tokenSessionToken) {
-        expect(token.tokenId).to.length(64);
-        expect(token.tokenId).to.eql(tokenId);
-
-        expect(token.authKey).to.length(64);
-        expect(token.authKey).to.eql(tokenAuthKey);
-
-        expect(token.sessionToken).to.length(64);
-        expect(token.sessionToken).to.eql(tokenSessionToken);
+        expect(tokenId).to.length(64);
+        expect(tokenAuthKey).to.length(64);
+        expect(tokenSessionToken).to.length(64);
         expect(sessionToken).to.eql(tokenSessionToken);
         done();
       });


### PR DESCRIPTION
Because the operation to generate them is async, it doesn't really make sense
to have them inside the object itself.

Having one API to get them seems simpler to deal with in the future, and avoids
future possible confusion (say people trying to use these values when they
don't exist yet).
