### PR TITLE
Define how should look like the MT manual code.

### DIFF
--- a/API.md
+++ b/API.md
@@ -344,7 +344,7 @@ aac4b1e3f1791ef83886c27519979b93a45e6d0da34c7509ca632aca5a28a47c
 
 (`shortVerificationCode` is `true`)
 ```
-Your verification code: e3c5b
+Your verification code: 146193
 ```
 
 ## SMS /v1/msisdn/sms/momt/verify
@@ -391,7 +391,7 @@ curl -v \
 "https://msisdn.accounts.firefox.com/v1/msisdn/sms/verify_code" \
 -H 'Authorization: Hawk id="d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c7509c5632ac35b28b48d", ts="1373391043", nonce="ohQjqb", hash="vBODPWhDhiRWM4tmI9qp+np+3aoqEFzdGuGk0h7bh9w=", mac="LAnpP3P2PXelC6hUoUaHP72nCqY5Iibaa3eeiGBqIIU="' \
 -d '{
-  "code": "e3c5b"
+  "code": "146193"
 }'
 ```
 


### PR DESCRIPTION
In the new documentation @ckarlof defined the code to be:

```
e3c5b
```

I think it should be 6 digits lengths because we can then display a digit keyboard to the phone user that will be easier for him to use also 6 digits lets us 10M possibilities which are more than enough if we only accept 2 or 3 tries before sending a new one.

Can we agree on changing that and make it 6 digits length for the manual code method?
