### PR TITLE
Make the load test Py26 compatible

### DIFF
--- a/loadtests/loadtest.py
+++ b/loadtests/loadtest.py
@@ -145,8 +145,8 @@ class TestMSISDN(TestCase):
         start_time = time.time()
 
         #  Poll on the omxen message list for this number
-        while len(messages) < 1 and \
-                time.time() - start_time < MAX_OMXEN_TIMEOUT:
+        while (len(messages) < 1 and
+               time.time() - start_time < MAX_OMXEN_TIMEOUT):
             time.sleep(1)
             resp = self.session.get(self.omxen_url + '/receive',
                                     params={"to": self.msisdn.lstrip("+")})


### PR DESCRIPTION
Made the load test py2.6 compliant and verified it worked against the stage server
