### PR TITLE
jshint make target is missing a few directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ cover-mocha:
 
 .PHONY: jshint
 jshint:
-	@$(NODE_LOCAL_BIN)/jshint test msisdn-gateway/*.js
+	@$(NODE_LOCAL_BIN)/jshint test/*.js msisdn-gateway/*.js msisdn-gateway/*/*.js tools/*.js
 
 .PHONY: mocha
 mocha:

--- a/msisdn-gateway/sms/nexmo.js
+++ b/msisdn-gateway/sms/nexmo.js
@@ -10,7 +10,7 @@ var querystring = require("querystring");
 
 function Nexmo(options) {
   this._conf = options;
-  if (!this._conf.endpoint === '') {
+  if (this._conf.endpoint === '') {
     throw new Error("You should configure Nexmo credentials first.");
   }
 }

--- a/msisdn-gateway/storage/proxy.js
+++ b/msisdn-gateway/storage/proxy.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 "use strict";
-var getStorage = require("./index")
+var getStorage = require("./index");
 
 
 function StorageProxy(conf, options) {

--- a/tools/test_encryption.js
+++ b/tools/test_encryption.js
@@ -6,7 +6,7 @@
 "use strict";
 
 var encrypt = require("../msisdn-gateway/encrypt");
-var digitsCode = require("../msisdn-gateway/utils").digitsCode;
+// var digitsCode = require("../msisdn-gateway/utils").digitsCode;
 
 var HawkId = "c27f3318d9df06fec997f6fbad54893789547cc28327789d5a83a26bd80b4206";
 var MSISDN = "+33508866481";


### PR DESCRIPTION
Currently it looks like we're missing a few files/folders in the `make jshint` target ([Makefile:34-35](https://github.com/mozilla-services/msisdn-gateway/blob/54f1eba43336e7b7c3cbf0411fec469b1e05ee13/Makefile#L34-L35)):

``` sh
$ make jshint && echo $?
0
```

But it doesn't look like we're linting all the files.

``` sh
$ jshint msisdn-gateway/ test/*.js tools/*.js
msisdn-gateway/sms/nexmo.js: line 13, col 7, Confusing use of '!'.

msisdn-gateway/storage/proxy.js: line 6, col 36, Missing semicolon.

tools/test_encryption.js: line 5, col 5, 'digitsCode' is defined but never used.

3 errors
```
