### PR TITLE
adding a couple of npm scripts and tweaking travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ services: redis-server
 before_script:
   - gem install fake_dynamo
   - npm run outdated
+  - npm run audit-shrinkwrap
   - make lint

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "test": "make test",
     "start": "make runserver",
     "outdated": "npm outdated --depth 0",
-    "lint": "eslint msisdn-gateway test tools"
+    "lint": "eslint msisdn-gateway test tools",
+    "lint-jsdoc": "eslint msisdn-gateway tools --rule 'valid-jsdoc: [1, {requireReturn:false}]'",
+    "audit-shrinkwrap": "npm shrinkwrap --dev && nsp audit-shrinkwrap || true"
   },
   "license": "MPL-2.0",
   "keywords": []


### PR DESCRIPTION
Added 2 new tasks:
1. `npm run lint-jsdoc` &mdash; Uses ESLint to check for valid/missing JSDoc comments. This only causes warnings if you run it locally and won't fail any builds.
2. `npm run audit-shrinkwrap` &mdash; Uses [**nsp**](https://github.com/nodesecurity/nsp) to check a npm-shrinkwrap.json file for any known vuln modules in the https://nodesecurity.io database. This script will create a npm-shrinkwrap.json file and uses `|| true` to make sure the exit code is always 0 so it won't fail the Travis build.

I also tweaked the .travis.yml file to log out any known questionable modules using `npm run audit-shrinkwrap`.
