### PR TITLE
Upgrade dependency from jwcrypto to browserid-crypto.

### DIFF
--- a/API.md
+++ b/API.md
@@ -463,7 +463,7 @@ curl -v \
 
 ___Parameters___
 * `publicKey` - the key to sign (run `bin/generate-keypair` from
-  [jwcrypto](https://github.com/mozilla/jwcrypto))
+  [browserid-crypto](https://github.com/mozilla/browserid-crypto))
     * algorithm - "RS" or "DS"
     * n - RS only
     * e - RS only

--- a/bin/generate-keypair
+++ b/bin/generate-keypair
@@ -3,13 +3,13 @@
 // generate a keypair quick
 //
 
-var jwcrypto = require("jwcrypto");
+var bidcrypto = require("browserid-crypto");
 
-require("jwcrypto/lib/algs/ds");
-require("jwcrypto/lib/algs/rs");
+require("browserid-crypto/lib/algs/ds");
+require("browserid-crypto/lib/algs/rs");
 
-jwcrypto.generateKeypair({
-    algorithm: "DSA",
+bidcrypto.generateKeypair({
+    algorithm: "DS",
     keysize: 256
   }, function(err, keypair) {
     if (err) {

--- a/msisdn-gateway/routes/browser-id.js
+++ b/msisdn-gateway/routes/browser-id.js
@@ -4,18 +4,18 @@
 
 "use strict";
 
-var jwcrypto = require('jwcrypto');
+var bidcrypto = require('browserid-crypto');
 
 // Make sure to load supported algorithms.
-require('jwcrypto/lib/algs/rs');
-require('jwcrypto/lib/algs/ds');
+require('browserid-crypto/lib/algs/rs');
+require('browserid-crypto/lib/algs/ds');
 
 
 module.exports = function(app, conf) {
   /***********************
    * BrowserId IdP views *
    ***********************/
-  var _publicKey = jwcrypto.loadPublicKeyFromObject(conf.get('BIDPublicKey'));
+  var _publicKey = bidcrypto.loadPublicKeyFromObject(conf.get('BIDPublicKey'));
 
   /**
    * Well known BrowserId

--- a/msisdn-gateway/routes/certificate.js
+++ b/msisdn-gateway/routes/certificate.js
@@ -10,14 +10,14 @@ var requireParams = require("./utils").requireParams;
 var validateJWCryptoKey = require("../utils").validateJWCryptoKey;
 var generateCertificate = require("../utils").generateCertificate;
 
-var jwcrypto = require('jwcrypto');
+var bidcrypto = require('browserid-crypto');
 
 // Make sure to load supported algorithms.
-require('jwcrypto/lib/algs/rs');
-require('jwcrypto/lib/algs/ds');
+require('browserid-crypto/lib/algs/rs');
+require('browserid-crypto/lib/algs/ds');
 
 module.exports = function(app, conf, logError, storage, hawkMiddleware) {
-  var _privKey = jwcrypto.loadSecretKeyFromObject(conf.get('BIDSecretKey'));
+  var _privKey = bidcrypto.loadSecretKeyFromObject(conf.get('BIDSecretKey'));
 
   var encrypt;
   if (conf.get("fakeEncrypt")) {

--- a/msisdn-gateway/utils.js
+++ b/msisdn-gateway/utils.js
@@ -6,7 +6,7 @@
 
 var crypto = require("crypto");
 var uuid = require('node-uuid');
-var jwcrypto = require('jwcrypto');
+var bidcrypto = require('browserid-crypto');
 
 
 /**
@@ -62,8 +62,8 @@ function generateCertificate(msisdn, host, publicKey, privateKey, duration,
   md5sum.update(msisdn);
   var msisdn_uuid = uuid.unparse(md5sum.digest());
 
-  jwcrypto.cert.sign({
-    publicKey: jwcrypto.loadPublicKeyFromObject(publicKey),
+  bidcrypto.cert.sign({
+    publicKey: bidcrypto.loadPublicKeyFromObject(publicKey),
     principal: { email: msisdn_uuid + "@" + host}
   }, {
     issuer: host,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "aws-sdk": "2.0.11",
+    "browserid-crypto": "0.7.0",
     "convict": "0.4.2",
     "cors": "2.2.0",
     "express": "3.x",
@@ -25,7 +26,6 @@
     "hkdf": "0.0.2",
     "i18n-abide": "0.0.22",
     "jsxgettext-recursive": "0.0.5",
-    "jwcrypto": "0.5.0",
     "node-uuid": "1.4.1",
     "phone": "git://github.com/Natim/node-phone.git#83a4f48",
     "raven": "0.7.0",

--- a/tools/test_cert.js
+++ b/tools/test_cert.js
@@ -7,18 +7,18 @@
 
 var gen = require("../msisdn-gateway/utils").generateCertificate;
 
-var jwcrypto = require('jwcrypto');
+var bidcrypto = require('browserid-crypto');
 
 // Make sure to load supported algorithms.
-require('jwcrypto/lib/algs/rs');
-require('jwcrypto/lib/algs/ds');
+require('browserid-crypto/lib/algs/rs');
+require('browserid-crypto/lib/algs/ds');
 
 var request = require('request');
 var conf = require('./test_cert_conf.json');
 
-var serverPrivateKey = jwcrypto.loadSecretKeyFromObject(conf.BIDSecretKey);
+var serverPrivateKey = bidcrypto.loadSecretKeyFromObject(conf.BIDSecretKey);
 var clientPublicKey = conf.clientPublicKey;
-var clientPrivateKey = jwcrypto.loadSecretKeyFromObject(conf.clientSecretKey);
+var clientPrivateKey = bidcrypto.loadSecretKeyFromObject(conf.clientSecretKey);
 var msisdn = conf.msisdn || "xxx";
 var duration = parseInt(conf.duration, 10) || 3600;
 var audience = conf.audience || "http://loop.dev.mozaws.net";
@@ -32,12 +32,12 @@ function createAssertion(cert, cb) {
   var issuedAt = Date.now();
   var expiresAt = (issuedAt + (2 * 60 * 1000));
 
-  jwcrypto.assertion.sign(
+  bidcrypto.assertion.sign(
     {}, {audience: audience, expiresAt: expiresAt, issuedAt: issuedAt},
     clientPrivateKey,
     function(err, signedContents) {
       if (err) return cb(err);
-      var assertion = jwcrypto.cert.bundle([cert], signedContents);
+      var assertion = bidcrypto.cert.bundle([cert], signedContents);
       cb(null, assertion);
     });
 }


### PR DESCRIPTION
This is a simple search-and-replace-style update from jwcrypto v0.5.0 to browserid-crypto v0.7.0.  All the APIs are the same, but this will remove support for "new-style" certificate formats that was present in jwcrypto.  Any `BIDPublicKey` or `BIDSecretKey` values that have a `kty` field will not be compatible with this change, and should be re-formatted into the "old-style" data format.
